### PR TITLE
Allow progress tone to play when doorbell rings

### DIFF
--- a/asterisk/custom/extensions.conf
+++ b/asterisk/custom/extensions.conf
@@ -14,8 +14,9 @@ exten => _X!,1,Dial(${PJSIP_DIAL_CONTACTS(${EXTEN})})
 
 ; VTO will call this number when someone presses the button
 exten => 9901,1,NoOp()
-same => n,Answer()
+same => n,Progress()
 same => n,System(/config/asterisk/perform_ha_action.sh input_boolean.turn_on entity_id input_boolean.doorbell_calling)
+same => n,Wait(30)
 same => n,Hangup()
 
 [parkedcallstimeout]

--- a/home-assistant/automations/doorbell-ringed.yaml
+++ b/home-assistant/automations/doorbell-ringed.yaml
@@ -7,9 +7,6 @@ trigger:
       - input_boolean.doorbell_calling
     to: "on"
 action:
-  - action: dahua.vto_cancel_call
-    target:
-      entity_id: camera.doorbell_dahua_main
   - action: fully_kiosk.load_url
     data:
       url: http://home-assistant.local/lovelace/doorbell

--- a/home-assistant/dashboards/doorbell.yaml
+++ b/home-assistant/dashboards/doorbell.yaml
@@ -67,6 +67,15 @@ cards:
             buttons:
               microphone:
                 enabled: true
+    automations:
+      - conditions:
+          - condition: microphone
+            connected: true
+        actions:
+          - action: perform-action
+            perform_action: dahua.vto_cancel_call
+            data:
+              entity_id: camera.doorbell_dahua_main
     elements:
       - type: custom:advanced-camera-card-conditional
         conditions:


### PR DESCRIPTION
Previously, when someone rings the doorbell, it would say _Calling now, please wait a moment..._ and then would become silent with no further feedback.

Now, when someone rings the doorbell, it will say _Calling now, please wait a moment..._ and then it will continue to play the progress tone until the call is answered or not. When the call is not answered, it will say _No one answered the call, please try again later._

This provides better feedback to the user about the status of the call.
