### PR TITLE
Add button to restart go2rtc and reload dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,18 +145,4 @@ You will need to [create two `input_boolean`s](https://www.home-assistant.io/int
 
 The integration also uses the [`ringtone.mp3`](./home-assistant/www/asterisk/ringtone.mp3) to emulate a call by playing it on the tablet. Make sure such file is in your `/config/www/asterisk/` folder.
 
-I created notification groups for my mobile devices and for my TVs to simplify my automation. If you want to do the same, it's as simple as adding this to your Home Assistant `configuration.yaml`:
-
-```yaml
-notify:
-  - name: all_phones
-    platform: group
-    services:
-      - action: mobile_app_phone_a
-      - action: mobile_app_phone_b
-  - name: all_tvs
-    platform: group
-    services:
-      - action: kitchen_tv
-      - action: bedroom_tv
-```
+I created notification groups for my mobile devices and for my TVs to simplify my automation. If you want to do the same, check [`configuration.yaml`](./home-assistant/configuration.yaml) for a reference.

--- a/home-assistant/configuration.yaml
+++ b/home-assistant/configuration.yaml
@@ -1,0 +1,26 @@
+notify:
+  - name: all_phones
+    platform: group
+    services:
+      - action: mobile_app_phone_a
+      - action: mobile_app_phone_b
+  - name: all_tvs
+    platform: group
+    services:
+      - action: kitchen_tv
+      - action: bedroom_tv
+
+rest_command:
+  restart_go2rtc:
+    method: POST
+    url: http://ccab4aaf-frigate:1984/api/restart
+
+template:
+  - button:
+    - name: Restart go2rtc
+      unique_id: 67815cb0-891e-4bae-b4cc-ebf0fcae7bf6
+      icon: mdi:restart
+      # Requires enabling the entity in Devices & services > Supervisor > Frigate > Controls
+      availability: "{{ is_state('switch.frigate', 'on') }}"
+      press:
+        action: rest_command.restart_go2rtc

--- a/home-assistant/dashboards/doorbell.yaml
+++ b/home-assistant/dashboards/doorbell.yaml
@@ -153,6 +153,16 @@ cards:
                 advanced_camera_card_action: microphone_disconnect
               - action: custom:advanced-camera-card-action
                 advanced_camera_card_action: mute
+      - type: custom:advanced-camera-card-menu-icon
+        title: Reload
+        icon: mdi:reload
+        tap_action:
+          - action: perform-action
+            perform_action: button.press
+            data:
+              entity_id: button.restart_go2rtc
+          - action: custom:advanced-camera-card-action
+            advanced_camera_card_action: reload
       - type: custom:advanced-camera-card-menu-state-icon
         entity: input_boolean.do_not_disturb
         state_color: true


### PR DESCRIPTION
Useful in case of some little emergency when you need to answer the doorbell in a hurry but something is not working for whatever reason.

- Refs https://github.com/dermotduffy/advanced-camera-card/issues/2215